### PR TITLE
Improve ship placement error handling

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -57,8 +57,7 @@ impl BoardState {
             return Err(BoardError::InvalidIndex);
         }
         let def = SHIPS[ship_index];
-        let (ship, mask) = Ship::<u128, { BOARD_SIZE as usize }>::new(def, orientation, row, col)
-            .map_err(|_| BoardError::ShipOutOfBounds)?;
+        let (_ship, mask) = Ship::<u128, { BOARD_SIZE as usize }>::new(def, orientation, row, col)?;
         // ensure no overlap
         if (self.ship_map & mask).count_ones() > 0 {
             return Err(BoardError::ShipOverlaps);

--- a/src/ship.rs
+++ b/src/ship.rs
@@ -3,6 +3,7 @@
 use core::fmt;
 use num_traits::{PrimInt, Unsigned, Zero};
 use crate::bitboard::BitBoard;
+use crate::common::BoardError;
 
 /// Orientation of a ship on the board.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,17 +60,15 @@ where
         orientation: Orientation,
         row: usize,
         col: usize,
-    ) -> Result<(Self, BitBoard<T, N>), &'static str> {
+    ) -> Result<(Self, BitBoard<T, N>), BoardError> {
         let len = ship_type.length();
         // Ensure placement fits within N×N
         if orientation == Orientation::Horizontal {
             if col + len > N {
-                return Err("Ship placement out of bounds");
+                return Err(BoardError::ShipOutOfBounds);
             }
-        } else {
-            if row + len > N {
-                return Err("Ship placement out of bounds");
-            }
+        } else if row + len > N {
+            return Err(BoardError::ShipOutOfBounds);
         }
 
         // Build occupancy mask
@@ -79,7 +78,7 @@ where
                 Orientation::Horizontal => (row, col + i),
                 Orientation::Vertical => (row + i, col),
             };
-            mask.set(r, c).map_err(|_| "Index error")?;
+            mask.set(r, c)?;
         }
 
         // Initialize empty hits board


### PR DESCRIPTION
## Summary
- add `ShipOutOfBounds` variant to `BoardError`
- return `BoardError` from `Ship::new`
- propagate typed errors in `BoardState::place`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6869cf7c58488329ba04cbdcf6956c4a