### PR TITLE
Fix variable name causing compile error

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -65,7 +65,7 @@ impl BoardState {
             return Err(BoardError::InvalidIndex);
         }
         let def = SHIPS[ship_index];
-        let (_ship, mask) = Ship::<u128, { BOARD_SIZE as usize }>::new(def, orientation, row, col)?;
+        let (ship, mask) = Ship::<u128, { BOARD_SIZE as usize }>::new(def, orientation, row, col)?;
         // ensure no overlap
         if (self.ship_map & mask).count_ones() > 0 {
             return Err(BoardError::ShipOverlaps);


### PR DESCRIPTION
## Summary
- fix board placement variable name so ship struct is available

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6869d31b69008329971e74ba9fff1b2a