### PR TITLE
Refactor board/ship types

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,11 @@
-use crate::ship::ShipType;
+use crate::ship::ShipDef;
 
 pub const BOARD_SIZE: u8 = 10;
 pub const NUM_SHIPS: usize = 5;
-pub const SHIPS: [ShipType; NUM_SHIPS] = [
-    ShipType::new("Carrier", 5),
-    ShipType::new("Battleship", 4),
-    ShipType::new("Cruiser", 3),
-    ShipType::new("Submarine", 3),
-    ShipType::new("Destroyer", 2),
+pub const SHIPS: [ShipDef; NUM_SHIPS] = [
+    ShipDef::new("Carrier", 5),
+    ShipDef::new("Battleship", 4),
+    ShipDef::new("Cruiser", 3),
+    ShipDef::new("Submarine", 3),
+    ShipDef::new("Destroyer", 2),
 ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use battleship::{BitBoard, Orientation, BoardState};
+use battleship::{BitBoard, Orientation, Board};
 
 fn main() {
     // Demonstrate basic bitboard usage
@@ -17,7 +17,7 @@ fn main() {
     println!("{}\n", board0 & board1);
 
     // Demonstrate board and ship placement
-    let mut state = BoardState::new();
+    let mut state = Board::new();
     state.place(0, 0, 0, Orientation::Horizontal).unwrap();
     state.place(1, 2, 2, Orientation::Vertical).unwrap();
     println!("Initial state: {:?}", state);

--- a/src/ship.rs
+++ b/src/ship.rs
@@ -13,15 +13,29 @@ pub enum Orientation {
     Vertical,
 }
 
-/// Type of ship: name and length.
+/// Public state of a ship on the board used for serialization or UI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ShipType {
+pub struct ShipState {
+    pub name: &'static str,
+    pub sunk: bool,
+}
+
+impl ShipState {
+    /// Create initial state for a ship.
+    pub const fn new(name: &'static str) -> Self {
+        ShipState { name, sunk: false }
+    }
+}
+
+/// Definition of a ship: name and length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShipDef {
     name: &'static str,
     length: usize,
 }
 
-impl ShipType {
-    /// Create a new ship type.
+impl ShipDef {
+    /// Create a new ship definition.
     pub const fn new(name: &'static str, length: usize) -> Self {
         Self { name, length }
     }
@@ -43,7 +57,7 @@ pub struct Ship<T, const N: usize>
 where
     T: PrimInt + Unsigned + Zero,
 {
-    ship_type: ShipType,
+    ship_type: ShipDef,
     orientation: Orientation,
     row: usize,
     col: usize,
@@ -58,7 +72,7 @@ where
     /// Place a ship at (`row`, `col`) with `orientation`.
     /// Returns the newly constructed ship.
     pub fn new(
-        ship_type: ShipType,
+        ship_type: ShipDef,
         orientation: Orientation,
         row: usize,
         col: usize,
@@ -112,7 +126,7 @@ where
     }
 
     /// Ship's type.
-    pub fn ship_type(&self) -> ShipType {
+    pub fn ship_type(&self) -> ShipDef {
         self.ship_type
     }
 

--- a/tests/board_tests.rs
+++ b/tests/board_tests.rs
@@ -1,10 +1,10 @@
-use battleship::{BoardError, BoardState, GuessResult, Orientation, NUM_SHIPS, SHIPS};
+use battleship::{BoardError, Board, GuessResult, Orientation, NUM_SHIPS, SHIPS};
 use rand::rngs::SmallRng;
 use rand::SeedableRng;
 
 #[test]
 fn test_manual_place_and_guess_sink() {
-    let mut board = BoardState::new();
+    let mut board = Board::new();
     board.place(0, 0, 0, Orientation::Horizontal).unwrap();
 
     for c in 0..SHIPS[0].length() - 1 {
@@ -26,7 +26,7 @@ fn test_manual_place_and_guess_sink() {
 
 #[test]
 fn test_place_random_no_overlap() {
-    let mut board = BoardState::new();
+    let mut board = Board::new();
     let mut rng = SmallRng::seed_from_u64(42);
     let ship_index = 0; // Carrier
     let (r, c, orient) = board.random_placement(&mut rng, ship_index).unwrap();
@@ -37,7 +37,7 @@ fn test_place_random_no_overlap() {
 
 #[test]
 fn test_place_random_all_ships_no_overlap() {
-    let mut board = BoardState::new();
+    let mut board = Board::new();
     let mut rng = SmallRng::seed_from_u64(42);
 
     let mut expected_bits = 0;


### PR DESCRIPTION
## Summary
- move ShipState struct to ship.rs and rename ShipType -> ShipDef
- rename BoardState to Board and add BoardState snapshot type
- update code and tests for new names

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686b1fa48fcc832991f2eb7416286bc0