### PR TITLE
Compute ship states dynamically

### DIFF
--- a/src/ship.rs
+++ b/src/ship.rs
@@ -18,12 +18,44 @@ pub enum Orientation {
 pub struct ShipState {
     pub name: &'static str,
     pub sunk: bool,
+    pub position: Option<(usize, usize, Orientation)>,
 }
 
 impl ShipState {
     /// Create initial state for a ship.
     pub const fn new(name: &'static str) -> Self {
-        ShipState { name, sunk: false }
+        ShipState {
+            name,
+            sunk: false,
+            position: None,
+        }
+    }
+}
+
+impl<T, const N: usize> From<&Ship<T, N>> for ShipState
+where
+    T: PrimInt + Unsigned + Zero,
+{
+    fn from(ship: &Ship<T, N>) -> Self {
+        ShipState {
+            name: ship.ship_type().name(),
+            sunk: ship.is_sunk(),
+            position: Some((ship.row, ship.col, ship.orientation)),
+        }
+    }
+}
+
+impl<T, const N: usize> Ship<T, N>
+where
+    T: PrimInt + Unsigned + Zero,
+{
+    /// Construct a ship from a [`ShipState`] if placement information is present.
+    pub fn from_state(state: &ShipState, def: ShipDef) -> Result<Option<Self>, BoardError> {
+        if let Some((row, col, orient)) = state.position {
+            Ok(Some(Ship::new(def, orient, row, col)?))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/tests/board_tests.rs
+++ b/tests/board_tests.rs
@@ -1,4 +1,5 @@
-use battleship::{BoardError, Board, GuessResult, Orientation, NUM_SHIPS, SHIPS};
+use battleship::{Board, BoardError, GuessResult, Orientation, BOARD_SIZE, NUM_SHIPS, SHIPS};
+use battleship::{BoardState, Ship};
 use rand::rngs::SmallRng;
 use rand::SeedableRng;
 
@@ -52,4 +53,33 @@ fn test_place_random_all_ships_no_overlap() {
         expected_bits,
         "all ships should be placed without overlap"
     );
+}
+
+#[test]
+fn test_board_state_roundtrip() {
+    let mut board = Board::new();
+    board.place(1, 2, 2, Orientation::Vertical).unwrap();
+    board.guess(2, 2).unwrap();
+
+    let state = BoardState::from(&board);
+    let mut board2: Board = state.into();
+
+    assert_eq!(board2.guess(2, 2).unwrap_err(), BoardError::AlreadyGuessed);
+    assert_eq!(
+        board2.ship_states()[1].position,
+        Some((2, 2, Orientation::Vertical))
+    );
+}
+
+#[test]
+fn test_ship_state_conversion() {
+    let mut board = Board::new();
+    board.place(2, 4, 1, Orientation::Horizontal).unwrap();
+    let states = board.ship_states();
+    let def = SHIPS[2];
+    let ship = Ship::<u128, { BOARD_SIZE as usize }>::from_state(&states[2], def)
+        .unwrap()
+        .unwrap();
+    assert_eq!(ship.origin(), (4, 1));
+    assert_eq!(ship.orientation(), Orientation::Horizontal);
 }


### PR DESCRIPTION
## Summary
- remove `ships` array from `BoardState`
- extend `ShipState` to optionally hold ship position
- compute ship states with position info
- convert `BoardState` into `Board` using `Ship::from_state`
- add tests for roundtripping board state and ship state conversion

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686b2465e34c832984fabb994a7f5aca