### PR TITLE
Implement GameEngine and GameState

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,3 +9,6 @@ pub const SHIPS: [ShipDef; NUM_SHIPS] = [
     ShipDef::new("Submarine", 3),
     ShipDef::new("Destroyer", 2),
 ];
+
+/// Total number of ship segments used in the standard configuration.
+pub const TOTAL_SHIP_CELLS: usize = 5 + 4 + 3 + 3 + 2;

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,0 +1,122 @@
+use crate::{
+    board::{Board, BoardState},
+    bitboard::BitBoard,
+    common::{BoardError, GuessResult},
+    config::{BOARD_SIZE, TOTAL_SHIP_CELLS},
+};
+
+/// Bitboard type used for game state tracking.
+type BB = BitBoard<u128, { BOARD_SIZE as usize }>;
+
+/// Public state of the player's guesses against the opponent.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GuessBoardState {
+    pub hits: BB,
+    pub misses: BB,
+}
+
+/// Serializable overall game state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GameState {
+    pub my_board: BoardState,
+    pub my_guesses: GuessBoardState,
+}
+
+/// Current status of a game.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GameStatus {
+    InProgress,
+    Won,
+    Lost,
+}
+
+/// Core game logic holding the player's board and guess history.
+pub struct GameEngine {
+    board: Board,
+    guess_hits: BB,
+    guess_misses: BB,
+    enemy_remaining: usize,
+}
+
+impl GameEngine {
+    /// Create a new engine with an empty board and no guesses recorded.
+    pub fn new() -> Self {
+        Self {
+            board: Board::new(),
+            guess_hits: BB::new(),
+            guess_misses: BB::new(),
+            enemy_remaining: TOTAL_SHIP_CELLS,
+        }
+    }
+
+    /// Mutable reference to the player's board for ship placement.
+    pub fn board_mut(&mut self) -> &mut Board {
+        &mut self.board
+    }
+
+    /// Immutable reference to the player's board.
+    pub fn board(&self) -> &Board {
+        &self.board
+    }
+
+    /// Handle an opponent guess on the player's board.
+    pub fn opponent_guess(&mut self, row: usize, col: usize) -> Result<GuessResult, BoardError> {
+        self.board.guess(row, col)
+    }
+
+    /// Record the result of a guess made against the opponent.
+    pub fn record_guess(
+        &mut self,
+        row: usize,
+        col: usize,
+        result: GuessResult,
+    ) -> Result<(), BoardError> {
+        if self.guess_hits.get(row, col)? || self.guess_misses.get(row, col)? {
+            return Err(BoardError::AlreadyGuessed);
+        }
+        match result {
+            GuessResult::Hit | GuessResult::Sink(_) => {
+                self.guess_hits.set(row, col)?;
+                self.enemy_remaining = self.enemy_remaining.saturating_sub(1);
+            }
+            GuessResult::Miss => {
+                self.guess_misses.set(row, col)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Generate a serializable snapshot of the current state.
+    pub fn state(&self) -> GameState {
+        GameState {
+            my_board: BoardState::from(&self.board),
+            my_guesses: GuessBoardState {
+                hits: self.guess_hits,
+                misses: self.guess_misses,
+            },
+        }
+    }
+
+    /// Restore an engine from a previously saved state.
+    pub fn from_state(state: GameState) -> Self {
+        let enemy_remaining = TOTAL_SHIP_CELLS - state.my_guesses.hits.count_ones();
+        Self {
+            board: Board::from(state.my_board),
+            guess_hits: state.my_guesses.hits,
+            guess_misses: state.my_guesses.misses,
+            enemy_remaining,
+        }
+    }
+
+    /// Evaluate the current game status.
+    pub fn status(&self) -> GameStatus {
+        if self.board.all_sunk() {
+            GameStatus::Lost
+        } else if self.enemy_remaining == 0 {
+            GameStatus::Won
+        } else {
+            GameStatus::InProgress
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod bitboard;
 mod board;
 mod ship;
 mod config;
+mod game;
 //mod interface_cli;
 
 pub use bitboard::{BitBoard, BitBoardError};
@@ -11,4 +12,5 @@ pub use common::*;
 pub use board::*;
 pub use ship::*;
 pub use config::*;
+pub use game::*;
 //pub use interface_cli::*;

--- a/src/ship.rs
+++ b/src/ship.rs
@@ -78,7 +78,7 @@ impl ShipDef {
     }
 
     /// Ship's length.
-    pub fn length(&self) -> usize {
+    pub const fn length(&self) -> usize {
         self.length
     }
 }


### PR DESCRIPTION
## Summary
- add `GameEngine` and `GameState` for standalone game logic
- track opponent guesses and player guesses with new structs
- expose new module from the library
- allow const evaluation of `ShipDef::length`
- expose total ship cell count in config

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686b2ec3460883298e4211e362cc009f