### PR TITLE
Refactor: consolidate GameApi

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::engine_api::GameApi;
+use crate::protocol::GameApi;
 use std::io::{self, Write};
 
 pub async fn run_cli(api: Box<dyn GameApi>) -> anyhow::Result<()> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,8 +1,0 @@
-use crate::domain::*;
-#[async_trait::async_trait]
-pub trait GameApi: Send + Sync {
-    async fn make_guess(&mut self, x: u8, y: u8) -> anyhow::Result<GuessResult>;
-    async fn get_ship_status(&self, ship_id: usize) -> anyhow::Result<Ship>;
-    async fn sync_state(&mut self, payload: SyncPayload) -> anyhow::Result<()>;
-    fn status(&self) -> GameStatus;
-}

--- a/src/engine_api.rs
+++ b/src/engine_api.rs
@@ -1,8 +1,0 @@
-use crate::domain::*;
-#[async_trait::async_trait]
-pub trait GameApi: Send + Sync {
-    async fn make_guess(&mut self, x: u8, y: u8) -> anyhow::Result<GuessResult>;
-    async fn get_ship_status(&self, ship_id: usize) -> anyhow::Result<Ship>;
-    async fn sync_state(&mut self, payload: SyncPayload) -> anyhow::Result<()>;
-    fn status(&self) -> GameStatus;
-}

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -1,4 +1,4 @@
-use crate::{engine_api::GameApi, protocol::Message, transport::Transport};
+use crate::{protocol::GameApi, protocol::Message, transport::Transport};
 pub struct Skeleton<E: GameApi, T: Transport> { engine: E, transport: T }
 impl<E: GameApi, T: Transport> Skeleton<E, T> {
     pub async fn run(&mut self) -> anyhow::Result<()> {

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -1,4 +1,4 @@
-use crate::{engine_api::GameApi, protocol::Message, transport::Transport};
+use crate::{protocol::GameApi, protocol::Message, transport::Transport};
 pub struct Stub<T: Transport> { transport: T }
 #[async_trait::async_trait]
 impl<T: Transport> GameApi for Stub<T> {


### PR DESCRIPTION
## Summary
- centralize the `GameApi` trait in `protocol.rs`
- remove redundant `engine.rs` and `engine_api.rs`
- update consumers (CLI, skeleton, stub) to import `GameApi` from `protocol`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686c695c04ec8329962e1c07efcad62c