### PR TITLE
Implement TCP transport and test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,36 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "autocfg"
@@ -15,12 +41,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
 name = "battleship"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "bincode",
  "num-traits",
  "rand",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -28,6 +82,12 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cfg-if"
@@ -44,7 +104,24 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -54,6 +131,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +164,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "ppv-lite86"
@@ -125,6 +243,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,10 +296,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "slab",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -149,6 +344,88 @@ checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,11 @@ edition = "2021"
 num-traits = { version = "0.2", default-features = false }
 rand = { version = "0.9.1", default-features = false, features = ["alloc", "small_rng"] }
 anyhow = { version = "1", default-features = false }
+async-trait = { version = "0.1", optional = true }
+tokio = { version = "1", features = ["net", "io-util", "rt", "macros"], optional = true, default-features = false }
+serde = { version = "1", features = ["derive"], optional = true }
+bincode = { version = "1", optional = true }
 
 [features]
 default = ["std"]
-std = ["rand/thread_rng", "anyhow/std"]
+std = ["rand/thread_rng", "anyhow/std", "tokio", "async-trait", "serde", "bincode"]

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,8 +1,24 @@
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct Board { /* grid, ships, hits/misses */ }
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ship { /* length, coords, orientation */ }
 
 #[derive(Debug, Clone)]
-pub enum GuessResult { Hit, Miss, Sink }
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub enum GuessResult {
+    Hit,
+    Miss,
+    Sink,
+}
+
 #[derive(Debug, Clone)]
-pub enum GameStatus { InProgress, Won, Lost }
-pub struct SyncPayload { /* serialized state diff */ }
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub enum GameStatus {
+    InProgress,
+    Won,
+    Lost,
+}
+
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone)]
+pub struct SyncPayload; /* serialized state diff */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate std;
 mod ai;
 mod bitboard;
 mod board;
+pub mod domain;
 mod common;
 mod config;
 mod game;
@@ -12,7 +13,13 @@ mod player;
 mod player_ai;
 #[cfg(feature = "std")]
 mod player_cli;
+pub mod protocol;
+pub mod transport;
+#[cfg(feature = "std")]
+pub mod transport_tcp;
 mod ship;
+pub mod skeleton;
+pub mod stub;
 //mod interface_cli;
 
 pub use ai::*;
@@ -25,5 +32,8 @@ pub use player::*;
 pub use player_ai::*;
 #[cfg(feature = "std")]
 pub use player_cli::*;
+pub use protocol::*;
 pub use ship::*;
+pub use skeleton::*;
+pub use stub::*;
 //pub use interface_cli::*;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,7 +1,11 @@
 use crate::domain::*;
 
+#[cfg(feature = "std")]
+pub use async_trait;
+
 /// Messages exchanged between the game engine and a remote client.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum Message {
     /// Request to make a guess at the given coordinates.
     Guess { x: u8, y: u8 },
@@ -13,4 +17,12 @@ pub enum Message {
     Sync(SyncPayload),
     /// Generic acknowledgement.
     Ack,
+}
+
+#[cfg_attr(feature = "std", async_trait::async_trait)]
+pub trait GameApi: Send + Sync {
+    async fn make_guess(&mut self, x: u8, y: u8) -> anyhow::Result<GuessResult>;
+    async fn get_ship_status(&self, ship_id: usize) -> anyhow::Result<Ship>;
+    async fn sync_state(&mut self, payload: SyncPayload) -> anyhow::Result<()>;
+    fn status(&self) -> GameStatus;
 }

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -1,6 +1,14 @@
 use crate::{protocol::GameApi, protocol::Message, transport::Transport};
-pub struct Skeleton<E: GameApi, T: Transport> { engine: E, transport: T }
+
+pub struct Skeleton<E: GameApi, T: Transport> {
+    engine: E,
+    transport: T,
+}
+
 impl<E: GameApi, T: Transport> Skeleton<E, T> {
+    pub fn new(engine: E, transport: T) -> Self {
+        Self { engine, transport }
+    }
     pub async fn run(&mut self) -> anyhow::Result<()> {
         while let Ok(msg) = self.transport.recv().await {
             let reply = match msg {

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -1,5 +1,14 @@
 use crate::{protocol::GameApi, protocol::Message, transport::Transport};
-pub struct Stub<T: Transport> { transport: T }
+use crate::domain::{GuessResult, Ship, SyncPayload, GameStatus};
+pub struct Stub<T: Transport> {
+    transport: T,
+}
+
+impl<T: Transport> Stub<T> {
+    pub fn new(transport: T) -> Self {
+        Self { transport }
+    }
+}
 #[async_trait::async_trait]
 impl<T: Transport> GameApi for Stub<T> {
     async fn make_guess(&mut self, x: u8, y: u8) -> anyhow::Result<GuessResult> {

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -1,16 +1,3 @@
 #![cfg(feature = "std")]
 
-use super::Transport;
-use crate::protocol::Message;
-
-pub struct TcpTransport;
-
-#[async_trait::async_trait]
-impl Transport for TcpTransport {
-    async fn send(&mut self, _msg: Message) -> anyhow::Result<()> {
-        unimplemented!()
-    }
-    async fn recv(&mut self) -> anyhow::Result<Message> {
-        unimplemented!()
-    }
-}
+pub use crate::transport_tcp::*;

--- a/src/transport_tcp.rs
+++ b/src/transport_tcp.rs
@@ -1,0 +1,46 @@
+#[cfg(feature = "std")]
+use tokio::net::{TcpStream, ToSocketAddrs};
+#[cfg(feature = "std")]
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::transport::Transport;
+use crate::protocol::Message;
+
+#[cfg(feature = "std")]
+pub struct TcpTransport {
+    stream: TcpStream,
+}
+
+#[cfg(feature = "std")]
+impl TcpTransport {
+    pub fn new(stream: TcpStream) -> Self {
+        Self { stream }
+    }
+
+    pub async fn connect<A: ToSocketAddrs>(addr: A) -> anyhow::Result<Self> {
+        let stream = TcpStream::connect(addr).await?;
+        Ok(Self::new(stream))
+    }
+}
+
+#[cfg(feature = "std")]
+#[async_trait::async_trait]
+impl Transport for TcpTransport {
+    async fn send(&mut self, msg: Message) -> anyhow::Result<()> {
+        let data = bincode::serialize(&msg)?;
+        let len = (data.len() as u32).to_be_bytes();
+        self.stream.write_all(&len).await?;
+        self.stream.write_all(&data).await?;
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> anyhow::Result<Message> {
+        let mut len_buf = [0u8; 4];
+        self.stream.read_exact(&mut len_buf).await?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+        let mut buf = vec![0u8; len];
+        self.stream.read_exact(&mut buf).await?;
+        let msg = bincode::deserialize(&buf)?;
+        Ok(msg)
+    }
+}

--- a/tests/tcp_transport_tests.rs
+++ b/tests/tcp_transport_tests.rs
@@ -1,0 +1,47 @@
+use battleship::transport_tcp::TcpTransport;
+use battleship::protocol::GameApi;
+use battleship::domain::{GuessResult, GameStatus, Ship, SyncPayload};
+use battleship::{Skeleton, Stub};
+use tokio::net::TcpListener;
+
+struct DummyEngine;
+
+#[async_trait::async_trait]
+impl GameApi for DummyEngine {
+    async fn make_guess(&mut self, _x: u8, _y: u8) -> anyhow::Result<GuessResult> {
+        Ok(GuessResult::Hit)
+    }
+    async fn get_ship_status(&self, _ship_id: usize) -> anyhow::Result<Ship> {
+        Ok(Ship {})
+    }
+    async fn sync_state(&mut self, _payload: SyncPayload) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn status(&self) -> GameStatus {
+        GameStatus::InProgress
+    }
+}
+
+#[tokio::test]
+async fn test_stub_skeleton_tcp() -> anyhow::Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+
+    let server = tokio::spawn(async move {
+        let (socket, _) = listener.accept().await.unwrap();
+        let transport = TcpTransport::new(socket);
+        let engine = DummyEngine;
+        let mut skeleton = Skeleton::new(engine, transport);
+        skeleton.run().await.unwrap();
+    });
+
+    let stream = TcpTransport::connect(addr).await?;
+    let mut stub = Stub::new(stream);
+
+    let res = stub.make_guess(1, 2).await?;
+    assert!(matches!(res, GuessResult::Hit));
+
+    drop(stub);
+    server.await.unwrap();
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement async TCP transport using Tokio
- expose protocol and domain APIs
- add constructors for `Skeleton` and `Stub`
- derive `Serialize`/`Deserialize` on network types
- add integration test showing `Stub` and `Skeleton` communicating

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686c71ab54048329ac76aa9fb074a530