### PR TITLE
Print probability distribution when choosing a guess

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,13 @@
-use battleship::{AiPlayer, CliPlayer, GameEngine, GameStatus, Player, print_player_view};
+use battleship::{
+    AiPlayer,
+    CliPlayer,
+    GameEngine,
+    GameStatus,
+    Player,
+    print_player_view,
+    print_probability_board,
+    calc_pdf,
+};
 use rand::rng;
 
 fn main() {
@@ -16,6 +25,12 @@ fn main() {
     loop {
         // show current boards before taking a turn
         print_player_view(&my_engine);
+        let pdf = calc_pdf(
+            &my_engine.guess_hits(),
+            &my_engine.guess_misses(),
+            &my_engine.enemy_ship_lengths_remaining(),
+        );
+        print_probability_board(&pdf);
 
         // player turn
         let guess = cli.select_target(

--- a/src/player_cli.rs
+++ b/src/player_cli.rs
@@ -94,6 +94,24 @@ fn print_guess_board(hits: &BB, misses: &BB) {
     }
 }
 
+/// Print a normalized probability distribution matrix.
+pub fn print_probability_board(pdf: &[[f64; BOARD_SIZE as usize]; BOARD_SIZE as usize]) {
+    std::println!("\nProbability distribution:");
+    std::print!("   ");
+    for c in 0..BOARD_SIZE as usize {
+        let ch = (b'A' + c as u8) as char;
+        std::print!(" {:>4}", ch);
+    }
+    std::println!();
+    for r in 0..BOARD_SIZE as usize {
+        std::print!("{:2} ", r + 1);
+        for c in 0..BOARD_SIZE as usize {
+            std::print!(" {:4.2}", pdf[r][c]);
+        }
+        std::println!();
+    }
+}
+
 /// Display the opponent board (top) and the player's board (bottom).
 pub fn print_player_view(engine: &GameEngine) {
     std::println!("Opponent board:");


### PR DESCRIPTION
## Summary
- add helper to display the probability matrix in the CLI player
- show the probability matrix each turn before prompting for a guess

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686c79ba41848329aaa5088492192d01