### PR TITLE
Add in-memory transport

### DIFF
--- a/src/transport/in_memory.rs
+++ b/src/transport/in_memory.rs
@@ -1,0 +1,56 @@
+#![cfg(feature = "std")]
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use tokio::task::yield_now;
+
+use crate::protocol::Message;
+use crate::transport::Transport;
+
+pub struct InMemoryTransport {
+    recv_queue: Arc<Mutex<VecDeque<Message>>>,
+    send_queue: Arc<Mutex<VecDeque<Message>>>,
+}
+
+impl InMemoryTransport {
+    pub fn pair() -> (Self, Self) {
+        let q1 = Arc::new(Mutex::new(VecDeque::new()));
+        let q2 = Arc::new(Mutex::new(VecDeque::new()));
+        (
+            Self {
+                recv_queue: q1.clone(),
+                send_queue: q2.clone(),
+            },
+            Self {
+                recv_queue: q2,
+                send_queue: q1,
+            },
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl Transport for InMemoryTransport {
+    async fn send(&mut self, msg: Message) -> anyhow::Result<()> {
+        let mut queue = self.send_queue.lock().unwrap();
+        queue.push_back(msg);
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> anyhow::Result<Message> {
+        loop {
+            if let Some(msg) = {
+                let mut queue = self.recv_queue.lock().unwrap();
+                queue.pop_front()
+            } {
+                return Ok(msg);
+            }
+            if Arc::strong_count(&self.recv_queue) == 1 {
+                return Err(anyhow::anyhow!("Channel closed"));
+            }
+            yield_now().await;
+        }
+    }
+}
+

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -8,3 +8,5 @@ pub trait Transport: Send + Sync {
 
 #[cfg(feature = "std")]
 pub mod tcp;
+#[cfg(feature = "std")]
+pub mod in_memory;

--- a/tests/in_memory_transport_tests.rs
+++ b/tests/in_memory_transport_tests.rs
@@ -1,0 +1,50 @@
+use battleship::transport::in_memory::InMemoryTransport;
+use battleship::protocol::GameApi;
+use battleship::domain::{GuessResult, GameStatus, Ship, SyncPayload};
+use battleship::{Skeleton, Stub};
+
+struct DummyEngine;
+
+#[async_trait::async_trait]
+impl GameApi for DummyEngine {
+    async fn make_guess(&mut self, _x: u8, _y: u8) -> anyhow::Result<GuessResult> {
+        Ok(GuessResult::Hit)
+    }
+    async fn get_ship_status(&self, _ship_id: usize) -> anyhow::Result<Ship> {
+        Ok(Ship { name: "dummy".to_string(), sunk: false, position: None })
+    }
+    async fn sync_state(&mut self, _payload: SyncPayload) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn status(&self) -> GameStatus {
+        GameStatus::InProgress
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_stub_skeleton_in_memory() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = InMemoryTransport::pair();
+
+    let server = tokio::spawn(async move {
+        let engine = DummyEngine;
+        let mut skeleton = Skeleton::new(engine, server_transport);
+        skeleton.run().await.unwrap();
+    });
+
+    let mut stub = Stub::new(client_transport);
+
+    let res = stub.make_guess(1, 2).await?;
+    assert!(matches!(res, GuessResult::Hit));
+
+    let ship = stub.get_ship_status(0).await?;
+    assert_eq!(ship.name, "dummy");
+
+    stub.sync_state(SyncPayload).await?;
+
+    let status = stub.status();
+    assert!(matches!(status, GameStatus::InProgress));
+
+    drop(stub);
+    server.await.unwrap();
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement an in-memory `Transport`
- expose the new module
- test skeleton/stub over the in-memory transport

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68745034286c83299a9e28325e096c15