### PR TITLE
Implement PlayerNode and make Player object-safe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod transport_tcp;
 mod ship;
 pub mod skeleton;
 pub mod stub;
+pub mod player_node;
 //mod interface_cli;
 
 pub use ai::*;
@@ -36,4 +37,5 @@ pub use protocol::*;
 pub use ship::*;
 pub use skeleton::*;
 pub use stub::*;
+pub use player_node::*;
 //pub use interface_cli::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,12 @@ use battleship::{
     print_probability_board,
     calc_pdf,
 };
-use rand::rng;
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
 
 fn main() {
-    let mut rng = rng();
+    let mut seed = rand::rng();
+    let mut rng = SmallRng::from_rng(&mut seed);
     let mut cli = CliPlayer::new();
     let mut ai = AiPlayer::new();
     let mut my_engine = GameEngine::new();

--- a/src/player.rs
+++ b/src/player.rs
@@ -5,19 +5,19 @@ use crate::{
     config::{BOARD_SIZE, NUM_SHIPS},
     BoardError,
 };
-use rand::Rng;
+use rand::rngs::SmallRng;
 
 type BB = BitBoard<u128, { BOARD_SIZE as usize }>;
 
 /// Interface implemented by different player types.
 pub trait Player {
     /// Place all ships onto the provided board.
-    fn place_ships<R: Rng>(&mut self, rng: &mut R, board: &mut Board) -> Result<(), BoardError>;
+    fn place_ships(&mut self, rng: &mut SmallRng, board: &mut Board) -> Result<(), BoardError>;
 
     /// Choose the next target coordinate given guess history and remaining enemy ships.
-    fn select_target<R: Rng>(
+    fn select_target(
         &mut self,
-        rng: &mut R,
+        rng: &mut SmallRng,
         hits: &BB,
         misses: &BB,
         remaining: &[usize; NUM_SHIPS as usize],

--- a/src/player_ai.rs
+++ b/src/player_ai.rs
@@ -6,7 +6,7 @@ use crate::{
     config::{BOARD_SIZE, NUM_SHIPS},
     BoardError,
 };
-use rand::Rng;
+use rand::rngs::SmallRng;
 
 use crate::player::Player;
 
@@ -22,7 +22,7 @@ impl AiPlayer {
 type BB = BitBoard<u128, { BOARD_SIZE as usize }>;
 
 impl Player for AiPlayer {
-    fn place_ships<R: Rng>(&mut self, rng: &mut R, board: &mut Board) -> Result<(), BoardError> {
+    fn place_ships(&mut self, rng: &mut SmallRng, board: &mut Board) -> Result<(), BoardError> {
         for i in 0..NUM_SHIPS as usize {
             let (r, c, o) = board.random_placement(rng, i)?;
             board.place(i, r, c, o)?;
@@ -30,9 +30,9 @@ impl Player for AiPlayer {
         Ok(())
     }
 
-    fn select_target<R: Rng>(
+    fn select_target(
         &mut self,
-        rng: &mut R,
+        rng: &mut SmallRng,
         hits: &BB,
         misses: &BB,
         remaining: &[usize; NUM_SHIPS as usize],

--- a/src/player_cli.rs
+++ b/src/player_cli.rs
@@ -12,7 +12,7 @@ use crate::{
     GameEngine,
     BoardError,
 };
-use rand::Rng;
+use rand::rngs::SmallRng;
 
 use crate::player::Player;
 
@@ -121,7 +121,7 @@ pub fn print_player_view(engine: &GameEngine) {
 }
 
 impl Player for CliPlayer {
-    fn place_ships<R: Rng>(&mut self, rng: &mut R, board: &mut Board) -> Result<(), BoardError> {
+    fn place_ships(&mut self, rng: &mut SmallRng, board: &mut Board) -> Result<(), BoardError> {
         std::println!("Place your ships (e.g. A5 H). Enter 'r' for random placement.");
         for i in 0..NUM_SHIPS as usize {
             let def = SHIPS[i];
@@ -158,9 +158,9 @@ impl Player for CliPlayer {
         Ok(())
     }
 
-    fn select_target<R: Rng>(
+    fn select_target(
         &mut self,
-        rng: &mut R,
+        rng: &mut SmallRng,
         hits: &BB,
         misses: &BB,
         remaining: &[usize; NUM_SHIPS as usize],

--- a/src/player_node.rs
+++ b/src/player_node.rs
@@ -1,0 +1,80 @@
+extern crate alloc;
+
+use alloc::boxed::Box;
+use rand::rngs::SmallRng;
+
+use crate::{
+    domain::GuessResult as DomainGuessResult,
+    game::GameStatus,
+    player::Player,
+    transport::Transport,
+    GameEngine, protocol::Message, common::GuessResult,
+};
+
+pub struct PlayerNode {
+    player: Box<dyn Player>,
+    engine: GameEngine,
+    transport: Box<dyn Transport>,
+}
+
+impl PlayerNode {
+    pub fn new(player: Box<dyn Player>, engine: GameEngine, transport: Box<dyn Transport>) -> Self {
+        Self { player, engine, transport }
+    }
+
+    pub async fn run(&mut self, rng: &mut SmallRng) -> anyhow::Result<()> {
+        loop {
+            // Receive opponent guess and respond
+            let msg = self.transport.recv().await?;
+            if let Message::Guess { x, y } = msg {
+                let res_common = self
+                    .engine
+                    .opponent_guess(x as usize, y as usize)
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                self.player
+                    .handle_opponent_guess((x as usize, y as usize), res_common);
+                let res_domain = DomainGuessResult::from(res_common);
+                self.transport
+                    .send(Message::StatusResp(res_domain))
+                    .await?;
+            } else {
+                continue;
+            }
+
+            if matches!(self.engine.status(), GameStatus::Lost) {
+                break;
+            }
+
+            // Choose our guess and send to opponent
+            let (r, c) = self.player.select_target(
+                rng,
+                &self.engine.guess_hits(),
+                &self.engine.guess_misses(),
+                &self.engine.enemy_ship_lengths_remaining(),
+            );
+            self.transport
+                .send(Message::Guess { x: r as u8, y: c as u8 })
+                .await?;
+            let reply = self.transport.recv().await?;
+            let res_domain = match reply {
+                Message::StatusResp(res) => res,
+                _ => return Err(anyhow::anyhow!("unexpected reply")),
+            };
+            let res_common = match res_domain {
+                DomainGuessResult::Hit => GuessResult::Hit,
+                DomainGuessResult::Miss => GuessResult::Miss,
+                DomainGuessResult::Sink => GuessResult::Hit,
+            };
+            self.engine
+                .record_guess(r, c, res_common)
+                .map_err(|e| anyhow::anyhow!(e))?;
+            self.player.handle_guess_result((r, c), res_common);
+
+            if !matches!(self.engine.status(), GameStatus::InProgress) {
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+


### PR DESCRIPTION
## Summary
- make Player trait object-safe using `SmallRng`
- implement `PlayerNode` running a local GameEngine and Player over a Transport
- update CLI, AI player and main to use the new Player API

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_687452912e68832995d07413b833fca9