### PR TITLE
Document unused CLI modules

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,9 @@
 #![cfg(feature = "std")]
 
+//! Experimental text-based client interface.
+//! This module is incomplete and may change without notice.
+//! It is only compiled when the `std` feature is enabled.
+
 use crate::protocol::GameApi;
 use std::io::{self, Write};
 

--- a/src/interface_cli.rs
+++ b/src/interface_cli.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "std")]
 
-use std::fmt;
+//! Experimental CLI helpers for displaying boards.
+//! This module is not fully integrated and may be removed.
+//! It is compiled only when the `std` feature is enabled.
 
 use crate::board::{Board, BoardError, GuessResult};
  


### PR DESCRIPTION
## Summary
- document that `cli` and `interface_cli` are experimental
- keep them gated behind the `std` feature

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687463759f348329a1bec9c46e3e7a0e