### PR TITLE
Fix sunk ship detection over transport

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,3 +12,14 @@ pub const SHIPS: [ShipDef; NUM_SHIPS] = [
 
 /// Total number of ship segments used in the standard configuration.
 pub const TOTAL_SHIP_CELLS: usize = 5 + 4 + 3 + 3 + 2;
+
+/// Convert a ship name string to the canonical static name used in the
+/// configuration. Returns `None` if the name does not match any defined ship.
+pub fn ship_name_static(name: &str) -> Option<&'static str> {
+    for def in SHIPS.iter() {
+        if def.name() == name {
+            return Some(def.name());
+        }
+    }
+    None
+}

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -4,7 +4,7 @@ use alloc::string::{String, ToString};
 use std::string::{String, ToString};
 
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-pub struct Board { /* grid, ships, hits/misses */ }
+pub struct Board {/* grid, ships, hits/misses */}
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ship {
@@ -18,7 +18,7 @@ pub struct Ship {
 pub enum GuessResult {
     Hit,
     Miss,
-    Sink,
+    Sink(String),
 }
 
 #[derive(Debug, Clone)]
@@ -38,7 +38,7 @@ impl From<crate::common::GuessResult> for GuessResult {
         match res {
             crate::common::GuessResult::Hit => GuessResult::Hit,
             crate::common::GuessResult::Miss => GuessResult::Miss,
-            crate::common::GuessResult::Sink(_) => GuessResult::Sink,
+            crate::common::GuessResult::Sink(name) => GuessResult::Sink(name.to_string()),
         }
     }
 }


### PR DESCRIPTION
## Summary
- include ship name in `domain::GuessResult`
- convert sink messages to `GuessResult::Sink` so AI can update its probability model
- add helper to map dynamic ship names to static strings

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68770b34b21483298ea6efd4d4218e1f