### PR TITLE
Add project README with module graph and usage commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Battleship
+
+Rust implementation of the classic Battleship game with support for AI opponents, a command-line interface, and networked play.
+
+## Module layout
+
+The crate is split into modules that expose game logic and optional transports:
+
+- `ai`: probability-based target selection.
+- `bitboard`: efficient bitboard representation of the game grid.
+- `board`: manages ship placement and guesses.
+- `common`: shared enums such as errors and guess results.
+- `config`: utilities like ship naming helpers.
+- `domain`: public types for boards, ships, and game status.
+- `game`: core game engine.
+- `player`: trait defining player behaviour.
+- `player_ai`: AI player implementation.
+- `player_cli`: interactive CLI player (requires `std`).
+- `player_node`: wrapper for running a player as a network node.
+- `protocol`: messages exchanged between components.
+- `ship`: ship definitions and logic.
+- `skeleton`: sample network client (requires `std`).
+- `stub`: protocol stub for testing (requires `std`).
+- `transport`: transport implementations such as TCP or in-memory (requires `std`).
+
+### Module graph
+
+```mermaid
+flowchart TD
+    battleship --> ai
+    battleship --> bitboard
+    battleship --> board
+    battleship --> common
+    battleship --> config
+    battleship --> domain
+    battleship --> game
+    battleship --> player
+    battleship --> player_ai
+    battleship --> player_cli
+    battleship --> player_node
+    battleship --> protocol
+    battleship --> ship
+    battleship --> skeleton
+    battleship --> stub
+    battleship --> transport
+```
+
+## Commands
+
+Build the project:
+
+```bash
+cargo build
+```
+
+Run the game:
+
+```bash
+cargo run
+```
+
+Execute the tests:
+
+```bash
+cargo test
+```
+


### PR DESCRIPTION
## Summary
- Document project purpose and module layout
- Include generated Mermaid diagram of crate modules
- List build, run, and test commands

## Testing
- `cargo build`
- `cargo run -- --help` *(interrupted after startup)*
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6898106c048c8329b0ae5f5dbade526c