### PR TITLE
Add protocol sequencing

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,5 +1,8 @@
 use crate::domain::*;
 
+/// Current protocol version.
+pub const PROTOCOL_VERSION: u8 = 1;
+
 #[cfg(feature = "std")]
 pub use async_trait;
 
@@ -8,23 +11,35 @@ pub use async_trait;
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum Message {
     /// Request to make a guess at the given coordinates.
-    Guess { x: u8, y: u8 },
+    Guess { version: u8, seq: u64, x: u8, y: u8 },
     /// Request the current game status.
-    StatusReq,
+    StatusReq { version: u8, seq: u64 },
     /// Response carrying the result of a guess.
-    StatusResp(GuessResult),
+    StatusResp {
+        version: u8,
+        seq: u64,
+        res: GuessResult,
+    },
     /// Synchronise state between peers.
-    Sync(SyncPayload),
+    Sync {
+        version: u8,
+        seq: u64,
+        payload: SyncPayload,
+    },
     /// Request the status of a particular ship by id.
-    ShipStatusReq { id: usize },
+    ShipStatusReq { version: u8, seq: u64, id: usize },
     /// Response containing the status of a ship.
-    ShipStatusResp(Ship),
+    ShipStatusResp { version: u8, seq: u64, ship: Ship },
     /// Request the overall game status.
-    GameStatusReq,
+    GameStatusReq { version: u8, seq: u64 },
     /// Response containing the current game status.
-    GameStatusResp(GameStatus),
+    GameStatusResp {
+        version: u8,
+        seq: u64,
+        status: GameStatus,
+    },
     /// Generic acknowledgement.
-    Ack,
+    Ack { version: u8, seq: u64 },
 }
 
 #[cfg_attr(feature = "std", async_trait::async_trait)]

--- a/src/skeleton.rs
+++ b/src/skeleton.rs
@@ -1,35 +1,122 @@
 #![cfg(feature = "std")]
 
-use crate::{protocol::GameApi, protocol::Message, transport::Transport};
+use crate::{
+    protocol::{GameApi, Message, PROTOCOL_VERSION},
+    transport::Transport,
+};
 
 pub struct Skeleton<E: GameApi, T: Transport> {
     engine: E,
     transport: T,
+    next_seq: u64,
 }
 
 impl<E: GameApi, T: Transport> Skeleton<E, T> {
     pub fn new(engine: E, transport: T) -> Self {
-        Self { engine, transport }
+        Self {
+            engine,
+            transport,
+            next_seq: 0,
+        }
     }
     pub async fn run(&mut self) -> anyhow::Result<()> {
         while let Ok(msg) = self.transport.recv().await {
-            let reply = match msg {
-                Message::Guess { x, y } => {
+            match msg {
+                Message::Guess { version, seq, x, y } => {
+                    if version != PROTOCOL_VERSION || seq != self.next_seq {
+                        self.transport
+                            .send(Message::Ack {
+                                version: PROTOCOL_VERSION,
+                                seq,
+                            })
+                            .await?;
+                        continue;
+                    }
+                    self.next_seq += 1;
                     let res = self.engine.make_guess(x, y).await?;
-                    Message::StatusResp(res)
+                    self.transport
+                        .send(Message::StatusResp {
+                            version: PROTOCOL_VERSION,
+                            seq,
+                            res,
+                        })
+                        .await?;
                 }
-                Message::StatusReq | Message::GameStatusReq => {
+                Message::StatusReq { version, seq } | Message::GameStatusReq { version, seq } => {
+                    if version != PROTOCOL_VERSION || seq != self.next_seq {
+                        self.transport
+                            .send(Message::Ack {
+                                version: PROTOCOL_VERSION,
+                                seq,
+                            })
+                            .await?;
+                        continue;
+                    }
+                    self.next_seq += 1;
                     let status = self.engine.status();
-                    Message::GameStatusResp(status)
+                    self.transport
+                        .send(Message::GameStatusResp {
+                            version: PROTOCOL_VERSION,
+                            seq,
+                            status,
+                        })
+                        .await?;
                 }
-                Message::ShipStatusReq { id } => {
+                Message::ShipStatusReq { version, seq, id } => {
+                    if version != PROTOCOL_VERSION || seq != self.next_seq {
+                        self.transport
+                            .send(Message::Ack {
+                                version: PROTOCOL_VERSION,
+                                seq,
+                            })
+                            .await?;
+                        continue;
+                    }
+                    self.next_seq += 1;
                     let ship = self.engine.get_ship_status(id).await?;
-                    Message::ShipStatusResp(ship)
+                    self.transport
+                        .send(Message::ShipStatusResp {
+                            version: PROTOCOL_VERSION,
+                            seq,
+                            ship,
+                        })
+                        .await?;
                 }
-                Message::Sync(payload) => { self.engine.sync_state(payload).await?; Message::Ack },
-                _ => Message::Ack,
-            };
-            self.transport.send(reply).await?;
+                Message::Sync {
+                    version,
+                    seq,
+                    payload,
+                } => {
+                    if version != PROTOCOL_VERSION || seq != self.next_seq {
+                        self.transport
+                            .send(Message::Ack {
+                                version: PROTOCOL_VERSION,
+                                seq,
+                            })
+                            .await?;
+                        continue;
+                    }
+                    self.next_seq += 1;
+                    self.engine.sync_state(payload).await?;
+                    self.transport
+                        .send(Message::Ack {
+                            version: PROTOCOL_VERSION,
+                            seq,
+                        })
+                        .await?;
+                }
+                Message::ShipStatusResp { .. }
+                | Message::StatusResp { .. }
+                | Message::GameStatusResp { .. }
+                | Message::Ack { .. } => {
+                    self.transport
+                        .send(Message::Ack {
+                            version: PROTOCOL_VERSION,
+                            seq: self.next_seq,
+                        })
+                        .await?;
+                }
+            }
         }
         Ok(())
     }

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -1,41 +1,81 @@
 #![cfg(feature = "std")]
 
-use crate::{protocol::GameApi, protocol::Message, transport::Transport};
-use crate::domain::{GuessResult, Ship, SyncPayload, GameStatus};
+use crate::domain::{GameStatus, GuessResult, Ship, SyncPayload};
+use crate::{
+    protocol::{GameApi, Message, PROTOCOL_VERSION},
+    transport::Transport,
+};
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::Mutex;
 
 pub struct Stub<T: Transport> {
     transport: Mutex<T>,
+    seq: AtomicU64,
 }
 
 impl<T: Transport> Stub<T> {
     pub fn new(transport: T) -> Self {
-        Self { transport: Mutex::new(transport) }
+        Self {
+            transport: Mutex::new(transport),
+            seq: AtomicU64::new(0),
+        }
+    }
+
+    fn next_seq(&self) -> u64 {
+        self.seq.fetch_add(1, Ordering::SeqCst)
     }
 }
 #[async_trait::async_trait]
 impl<T: Transport> GameApi for Stub<T> {
     async fn make_guess(&mut self, x: u8, y: u8) -> anyhow::Result<GuessResult> {
         let mut transport = self.transport.lock().await;
-        transport.send(Message::Guess { x, y }).await?;
+        let seq = self.next_seq();
+        transport
+            .send(Message::Guess {
+                version: PROTOCOL_VERSION,
+                seq,
+                x,
+                y,
+            })
+            .await?;
         match transport.recv().await? {
-            Message::StatusResp(res) => Ok(res),
+            Message::StatusResp {
+                seq: resp_seq, res, ..
+            } if resp_seq == seq => Ok(res),
             _ => Err(anyhow::anyhow!("Unexpected message")),
         }
     }
     async fn get_ship_status(&self, ship_id: usize) -> anyhow::Result<Ship> {
         let mut transport = self.transport.lock().await;
-        transport.send(Message::ShipStatusReq { id: ship_id }).await?;
+        let seq = self.next_seq();
+        transport
+            .send(Message::ShipStatusReq {
+                version: PROTOCOL_VERSION,
+                seq,
+                id: ship_id,
+            })
+            .await?;
         match transport.recv().await? {
-            Message::ShipStatusResp(ship) => Ok(ship),
+            Message::ShipStatusResp {
+                seq: resp_seq,
+                ship,
+                ..
+            } if resp_seq == seq => Ok(ship),
             _ => Err(anyhow::anyhow!("Unexpected message")),
         }
     }
     async fn sync_state(&mut self, payload: SyncPayload) -> anyhow::Result<()> {
         let mut transport = self.transport.lock().await;
-        transport.send(Message::Sync(payload)).await?;
+        let seq = self.next_seq();
+        transport
+            .send(Message::Sync {
+                version: PROTOCOL_VERSION,
+                seq,
+                payload,
+            })
+            .await?;
         match transport.recv().await? {
-            Message::Ack => Ok(()),
+            Message::Ack { seq: resp_seq, .. } if resp_seq == seq => Ok(()),
             _ => Err(anyhow::anyhow!("Unexpected message")),
         }
     }
@@ -43,9 +83,20 @@ impl<T: Transport> GameApi for Stub<T> {
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 let mut transport = self.transport.lock().await;
-                transport.send(Message::GameStatusReq).await.unwrap();
+                let seq = self.next_seq();
+                transport
+                    .send(Message::GameStatusReq {
+                        version: PROTOCOL_VERSION,
+                        seq,
+                    })
+                    .await
+                    .unwrap();
                 match transport.recv().await.unwrap() {
-                    Message::GameStatusResp(status) => status,
+                    Message::GameStatusResp {
+                        seq: resp_seq,
+                        status,
+                        ..
+                    } if resp_seq == seq => status,
                     _ => panic!("Unexpected message"),
                 }
             })

--- a/tests/sequence_tests.rs
+++ b/tests/sequence_tests.rs
@@ -1,0 +1,113 @@
+use battleship::domain::{GameStatus, GuessResult, Ship, SyncPayload};
+use battleship::protocol::GameApi;
+use battleship::transport::in_memory::InMemoryTransport;
+use battleship::transport::Transport;
+use battleship::{Message, Skeleton, PROTOCOL_VERSION};
+
+struct DummyEngine;
+
+#[async_trait::async_trait]
+impl GameApi for DummyEngine {
+    async fn make_guess(&mut self, _x: u8, _y: u8) -> anyhow::Result<GuessResult> {
+        Ok(GuessResult::Hit)
+    }
+    async fn get_ship_status(&self, _ship_id: usize) -> anyhow::Result<Ship> {
+        Ok(Ship {
+            name: "dummy".to_string(),
+            sunk: false,
+            position: None,
+        })
+    }
+    async fn sync_state(&mut self, _payload: SyncPayload) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn status(&self) -> GameStatus {
+        GameStatus::InProgress
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_out_of_order_message() -> anyhow::Result<()> {
+    let (server_transport, mut client_transport) = InMemoryTransport::pair();
+    let server = tokio::spawn(async move {
+        let engine = DummyEngine;
+        let mut skeleton = Skeleton::new(engine, server_transport);
+        skeleton.run().await.unwrap();
+    });
+
+    // Send out-of-order message (seq 1 when 0 expected)
+    client_transport
+        .send(Message::Guess {
+            version: PROTOCOL_VERSION,
+            seq: 1,
+            x: 0,
+            y: 0,
+        })
+        .await?;
+    match client_transport.recv().await? {
+        Message::Ack { seq, .. } => assert_eq!(seq, 1),
+        _ => panic!("expected Ack"),
+    }
+
+    // Send correct sequence
+    client_transport
+        .send(Message::Guess {
+            version: PROTOCOL_VERSION,
+            seq: 0,
+            x: 0,
+            y: 0,
+        })
+        .await?;
+    match client_transport.recv().await? {
+        Message::StatusResp { seq, res, .. } => {
+            assert_eq!(seq, 0);
+            assert!(matches!(res, GuessResult::Hit));
+        }
+        _ => panic!("expected StatusResp"),
+    }
+
+    drop(client_transport);
+    server.await.unwrap();
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_duplicate_message() -> anyhow::Result<()> {
+    let (server_transport, mut client_transport) = InMemoryTransport::pair();
+    let server = tokio::spawn(async move {
+        let engine = DummyEngine;
+        let mut skeleton = Skeleton::new(engine, server_transport);
+        skeleton.run().await.unwrap();
+    });
+
+    client_transport
+        .send(Message::Guess {
+            version: PROTOCOL_VERSION,
+            seq: 0,
+            x: 0,
+            y: 0,
+        })
+        .await?;
+    match client_transport.recv().await? {
+        Message::StatusResp { seq, .. } => assert_eq!(seq, 0),
+        _ => panic!("expected StatusResp"),
+    }
+
+    // Send duplicate seq 0
+    client_transport
+        .send(Message::Guess {
+            version: PROTOCOL_VERSION,
+            seq: 0,
+            x: 1,
+            y: 1,
+        })
+        .await?;
+    match client_transport.recv().await? {
+        Message::Ack { seq, .. } => assert_eq!(seq, 0),
+        _ => panic!("expected Ack"),
+    }
+
+    drop(client_transport);
+    server.await.unwrap();
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- extend protocol messages with `version` and `seq` fields
- track and verify message ordering in `Skeleton` and `Stub`
- test out-of-order and duplicate message handling

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6898106dab548329a9cf2291369c2866