### PR TITLE
Decouple CLI AI hints into dedicated UI module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ mod player_ai;
 #[cfg(feature = "std")]
 mod player_cli;
 #[cfg(feature = "std")]
+mod ui;
+#[cfg(feature = "std")]
 pub mod player_node;
 pub mod protocol;
 mod ship;
@@ -35,6 +37,8 @@ pub use player::*;
 pub use player_ai::*;
 #[cfg(feature = "std")]
 pub use player_cli::*;
+#[cfg(feature = "std")]
+pub use ui::*;
 #[cfg(feature = "std")]
 pub use player_node::*;
 pub use protocol::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,9 @@ fn main() {}
 
 #[cfg(feature = "std")]
 use battleship::{
-    calc_pdf, print_player_view, print_probability_board, ship_name_static,
-    transport::in_memory::InMemoryTransport, AiPlayer, CliPlayer, GameEngine, GameStatus, Player,
-    PlayerNode,
+    print_player_view, print_probability_board, ship_name_static,
+    transport::in_memory::InMemoryTransport, AiPlayer, AiSuggestion, CliPlayer, GameEngine,
+    GameStatus, Player, PlayerNode,
 };
 
 #[cfg(feature = "std")]
@@ -20,7 +20,7 @@ async fn main() -> anyhow::Result<()> {
     let mut rng_cli = SmallRng::from_rng(&mut seed);
     let mut rng_ai = SmallRng::from_rng(&mut seed);
 
-    let mut cli = CliPlayer::new();
+    let mut cli = CliPlayer::with_hint(Box::new(AiSuggestion));
     let mut ai = AiPlayer::new();
     let mut cli_engine = GameEngine::new();
     let mut ai_engine = GameEngine::new();
@@ -54,19 +54,19 @@ async fn run_cli(
     loop {
         if my_turn {
             print_player_view(&engine);
-            let pdf = calc_pdf(
-                &engine.guess_hits(),
-                &engine.guess_misses(),
-                &engine.enemy_ship_lengths_remaining(),
-            );
-            print_probability_board(&pdf);
-
-            let (r, c) = player.select_target(
+            let hint = player.calc_pdf_and_guess(
                 &mut rng,
                 &engine.guess_hits(),
                 &engine.guess_misses(),
                 &engine.enemy_ship_lengths_remaining(),
             );
+            let (r, c) = match hint {
+                Some((pdf, guess)) => {
+                    print_probability_board(&pdf);
+                    player.select_target_with_hint(Some(guess))
+                }
+                None => player.select_target_with_hint(None),
+            };
             transport
                 .send(battleship::Message::Guess {
                     x: r as u8,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,86 @@
+#![cfg(feature = "std")]
+
+use crate::{
+    bitboard::BitBoard,
+    config::{BOARD_SIZE, NUM_SHIPS},
+};
+use rand::rngs::SmallRng;
+
+// shorthand type for guess boards
+pub type BB = BitBoard<u128, { BOARD_SIZE as usize }>;
+
+/// Trait that allows the CLI to obtain AI suggestions without depending on the
+/// AI module directly.
+pub trait SuggestionProvider {
+    /// Return a probability distribution along with a suggested guess. If no
+    /// suggestion is available, return `None`.
+    fn calc_pdf_and_guess(
+        &mut self,
+        hits: &BB,
+        misses: &BB,
+        remaining: &[usize; NUM_SHIPS as usize],
+        rng: &mut SmallRng,
+    ) -> Option<(
+        [[f64; BOARD_SIZE as usize]; BOARD_SIZE as usize],
+        (usize, usize),
+    )>;
+}
+
+/// Implementation of [`SuggestionProvider`] that uses the real AI logic.
+pub struct AiSuggestion;
+
+impl SuggestionProvider for AiSuggestion {
+    fn calc_pdf_and_guess(
+        &mut self,
+        hits: &BB,
+        misses: &BB,
+        remaining: &[usize; NUM_SHIPS as usize],
+        rng: &mut SmallRng,
+    ) -> Option<(
+        [[f64; BOARD_SIZE as usize]; BOARD_SIZE as usize],
+        (usize, usize),
+    )> {
+        let pdf = crate::ai::calc_pdf(hits, misses, remaining);
+        let guess = crate::ai::sample_pdf(&pdf, 0.5, rng);
+        Some((pdf, guess))
+    }
+}
+
+/// [`SuggestionProvider`] that yields no suggestions.
+pub struct NoSuggestion;
+
+impl SuggestionProvider for NoSuggestion {
+    fn calc_pdf_and_guess(
+        &mut self,
+        _hits: &BB,
+        _misses: &BB,
+        _remaining: &[usize; NUM_SHIPS as usize],
+        _rng: &mut SmallRng,
+    ) -> Option<(
+        [[f64; BOARD_SIZE as usize]; BOARD_SIZE as usize],
+        (usize, usize),
+    )> {
+        None
+    }
+}
+
+/// Print a normalized probability distribution matrix.
+pub fn print_probability_board(
+    pdf: &[[f64; BOARD_SIZE as usize]; BOARD_SIZE as usize],
+) {
+    std::println!("\nProbability distribution:");
+    std::print!("   ");
+    for c in 0..BOARD_SIZE as usize {
+        let ch = (b'A' + c as u8) as char;
+        std::print!(" {:>4}", ch);
+    }
+    std::println!();
+    for r in 0..BOARD_SIZE as usize {
+        std::print!("{:2} ", r + 1);
+        for c in 0..BOARD_SIZE as usize {
+            std::print!(" {:4.2}", pdf[r][c]);
+        }
+        std::println!();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Move probability board rendering and AI suggestion logic into new `ui` module
- Introduce `SuggestionProvider` trait with `AiSuggestion` and `NoSuggestion` implementations
- Refactor CLI and main to use optional AI hints via the new trait

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6898106ec5e08329b5f28ae5713d8efb