### PR TITLE
Add BLE transport with chunked messaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ libm = { version = "0.2", default-features = false }
 [features]
 default = ["std"]
 std = ["rand/thread_rng", "anyhow/std", "tokio", "async-trait", "serde", "bincode"]
+ble = ["std"]

--- a/src/transport/ble.rs
+++ b/src/transport/ble.rs
@@ -1,0 +1,62 @@
+#![cfg(all(feature = "std", feature = "ble"))]
+
+use crate::protocol::Message;
+use crate::transport::Transport;
+
+/// Maximum payload size for a single BLE packet.
+const BLE_MTU: usize = 20;
+
+/// Placeholder trait representing the underlying BLE connection.
+#[async_trait::async_trait]
+pub trait BleConnection: Send + Sync {
+    /// Send a single chunk of bytes over the BLE link.
+    async fn write(&mut self, data: &[u8]) -> anyhow::Result<()>;
+
+    /// Receive a chunk of bytes from the BLE link.
+    async fn read(&mut self) -> anyhow::Result<Vec<u8>>;
+}
+
+/// Transport implementation backed by a BLE connection.
+pub struct BleTransport<C: BleConnection> {
+    conn: C,
+    recv_buf: Vec<u8>,
+}
+
+impl<C: BleConnection> BleTransport<C> {
+    /// Create a new transport from the given BLE connection.
+    pub fn new(conn: C) -> Self {
+        Self {
+            conn,
+            recv_buf: Vec::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<C: BleConnection> Transport for BleTransport<C> {
+    async fn send(&mut self, msg: Message) -> anyhow::Result<()> {
+        let data = bincode::serialize(&msg)?;
+        let mut frame = (data.len() as u32).to_be_bytes().to_vec();
+        frame.extend_from_slice(&data);
+        for chunk in frame.chunks(BLE_MTU) {
+            self.conn.write(chunk).await?; // placeholder BLE write
+        }
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> anyhow::Result<Message> {
+        loop {
+            if self.recv_buf.len() >= 4 {
+                let len = u32::from_be_bytes(self.recv_buf[0..4].try_into().unwrap()) as usize;
+                if self.recv_buf.len() >= 4 + len {
+                    let data = self.recv_buf[4..4 + len].to_vec();
+                    self.recv_buf.drain(..4 + len);
+                    let msg = bincode::deserialize(&data)?;
+                    return Ok(msg);
+                }
+            }
+            let chunk = self.conn.read().await?; // placeholder BLE read
+            self.recv_buf.extend_from_slice(&chunk);
+        }
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -8,7 +8,9 @@ pub trait Transport: Send + Sync {
     async fn recv(&mut self) -> anyhow::Result<Message>;
 }
 
-#[cfg(feature = "std")]
-pub mod tcp;
+#[cfg(all(feature = "std", feature = "ble"))]
+pub mod ble;
 #[cfg(feature = "std")]
 pub mod in_memory;
+#[cfg(feature = "std")]
+pub mod tcp;

--- a/tests/ble_transport_tests.rs
+++ b/tests/ble_transport_tests.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "ble")]
+
+use async_trait::async_trait;
+use battleship::protocol::Message;
+use battleship::transport::ble::{BleConnection, BleTransport};
+use battleship::transport::Transport;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use tokio::task::yield_now;
+
+struct MockBle {
+    recv_queue: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    send_queue: Arc<Mutex<VecDeque<Vec<u8>>>>,
+}
+
+impl MockBle {
+    fn pair() -> (Self, Self) {
+        let q1 = Arc::new(Mutex::new(VecDeque::new()));
+        let q2 = Arc::new(Mutex::new(VecDeque::new()));
+        (
+            Self {
+                recv_queue: q1.clone(),
+                send_queue: q2.clone(),
+            },
+            Self {
+                recv_queue: q2,
+                send_queue: q1,
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl BleConnection for MockBle {
+    async fn write(&mut self, data: &[u8]) -> anyhow::Result<()> {
+        let mut q = self.send_queue.lock().unwrap();
+        q.push_back(data.to_vec());
+        Ok(())
+    }
+
+    async fn read(&mut self) -> anyhow::Result<Vec<u8>> {
+        loop {
+            if let Some(chunk) = {
+                let mut q = self.recv_queue.lock().unwrap();
+                q.pop_front()
+            } {
+                return Ok(chunk);
+            }
+            if Arc::strong_count(&self.recv_queue) == 1 {
+                return Err(anyhow::anyhow!("Channel closed"));
+            }
+            yield_now().await;
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ble_round_trip() -> anyhow::Result<()> {
+    let (dev1, dev2) = MockBle::pair();
+    let mut t1 = BleTransport::new(dev1);
+    let mut t2 = BleTransport::new(dev2);
+
+    let msg = Message::Ack;
+    t1.send(msg.clone()).await?;
+    let recv = t2.recv().await?;
+    assert!(matches!(recv, Message::Ack));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement BLE transport with MTU chunking and reassembly
- expose BLE transport behind `ble` feature flag
- add basic round-trip BLE transport test

## Testing
- `cargo test --features ble`
- `cargo test --features ble --test ble_transport_tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689810795c1883298a269c9f927c6a7b