### PR TITLE
Add prelude module and consolidate imports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod player_ai;
 mod player_cli;
 #[cfg(feature = "std")]
 pub mod player_node;
+pub mod prelude;
 pub mod protocol;
 mod ship;
 pub mod skeleton;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,7 @@
 fn main() {}
 
 #[cfg(feature = "std")]
-use battleship::{
-    calc_pdf, print_player_view, print_probability_board, ship_name_static,
-    transport::in_memory::InMemoryTransport, AiPlayer, CliPlayer, GameEngine, GameStatus, Player,
-    PlayerNode,
-};
+use battleship::prelude::*;
 
 #[cfg(feature = "std")]
 use rand::rngs::SmallRng;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,9 @@
+//! Commonly used types and utilities for ease of import.
+
+pub use crate::{calc_pdf, ship_name_static, AiPlayer, GameEngine, GameStatus, Player};
+
+#[cfg(feature = "std")]
+pub use crate::{print_player_view, print_probability_board, CliPlayer, PlayerNode};
+
+#[cfg(feature = "std")]
+pub use crate::transport::{in_memory::InMemoryTransport, tcp::TcpTransport, Transport};

--- a/tests/ai_game_tests.rs
+++ b/tests/ai_game_tests.rs
@@ -1,4 +1,4 @@
-use battleship::{AiPlayer, GameEngine, GameStatus, Player};
+use battleship::prelude::*;
 use rand::rngs::SmallRng;
 use rand::SeedableRng;
 

--- a/tests/ai_transport_game.rs
+++ b/tests/ai_transport_game.rs
@@ -1,7 +1,4 @@
-use battleship::transport::in_memory::InMemoryTransport;
-use battleship::transport::Transport;
-use battleship::transport::tcp::TcpTransport;
-use battleship::{AiPlayer, GameEngine, GameStatus, Player, PlayerNode};
+use battleship::prelude::*;
 use rand::rngs::SmallRng;
 use rand::SeedableRng;
 use tokio::net::TcpListener;
@@ -29,7 +26,6 @@ async fn run_game(kind: TransportKind) -> anyhow::Result<()> {
             (Box::new(server), Box::new(client))
         }
     };
-
 
     let mut rng1 = SmallRng::seed_from_u64(1);
     let mut rng2 = SmallRng::seed_from_u64(2);


### PR DESCRIPTION
## Summary
- add prelude module exporting common types
- replace wide imports with `battleship::prelude::*`
- update integration tests to use the prelude

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6898109284208329b66f177eeb1f725b