### PR TITLE
Add logging for transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "libm",
+ "log",
  "num-traits",
  "rand",
  "serde",
@@ -136,6 +137,12 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ tokio = { version = "1", features = ["net", "io-util", "rt", "macros", "sync", "
 serde = { version = "1", features = ["derive"], optional = true }
 bincode = { version = "1", optional = true }
 libm = { version = "0.2", default-features = false }
+log = { version = "0.4", optional = true }
 
 [features]
 default = ["std"]
-std = ["rand/thread_rng", "anyhow/std", "tokio", "async-trait", "serde", "bincode"]
+std = ["rand/thread_rng", "anyhow/std", "tokio", "async-trait", "serde", "bincode", "log"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ mod game;
 mod player;
 mod player_ai;
 #[cfg(feature = "std")]
+mod logging;
+#[cfg(feature = "std")]
 mod player_cli;
 #[cfg(feature = "std")]
 pub mod player_node;
@@ -33,6 +35,8 @@ pub use config::*;
 pub use game::*;
 pub use player::*;
 pub use player_ai::*;
+#[cfg(feature = "std")]
+pub use logging::init_logging;
 #[cfg(feature = "std")]
 pub use player_cli::*;
 #[cfg(feature = "std")]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,32 @@
+#![cfg(feature = "std")]
+
+use std::env;
+use log::{self, LevelFilter, Metadata, Record};
+
+struct SimpleLogger;
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= log::max_level()
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            println!("{} - {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: SimpleLogger = SimpleLogger;
+
+/// Initialize logging with a level taken from the `BATTLESHIP_LOG` environment variable.
+/// Defaults to `info` if the variable is not set or invalid.
+pub fn init_logging() {
+    let level = env::var("BATTLESHIP_LOG")
+        .ok()
+        .and_then(|lvl| lvl.parse().ok())
+        .unwrap_or(LevelFilter::Info);
+    let _ = log::set_logger(&LOGGER).map(|()| log::set_max_level(level));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use rand::SeedableRng;
 #[cfg(feature = "std")]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    battleship::init_logging();
     let mut seed = rand::rng();
     let mut rng_cli = SmallRng::from_rng(&mut seed);
     let mut rng_ai = SmallRng::from_rng(&mut seed);

--- a/src/transport/in_memory.rs
+++ b/src/transport/in_memory.rs
@@ -33,6 +33,7 @@ impl InMemoryTransport {
 #[async_trait::async_trait]
 impl Transport for InMemoryTransport {
     async fn send(&mut self, msg: Message) -> anyhow::Result<()> {
+        log::debug!("mem send: {:?}", msg);
         let mut queue = self.send_queue.lock().unwrap();
         queue.push_back(msg);
         Ok(())
@@ -44,6 +45,7 @@ impl Transport for InMemoryTransport {
                 let mut queue = self.recv_queue.lock().unwrap();
                 queue.pop_front()
             } {
+                log::debug!("mem recv: {:?}", msg);
                 return Ok(msg);
             }
             if Arc::strong_count(&self.recv_queue) == 1 {

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -27,6 +27,7 @@ impl TcpTransport {
 #[async_trait::async_trait]
 impl Transport for TcpTransport {
     async fn send(&mut self, msg: Message) -> anyhow::Result<()> {
+        log::debug!("tcp send: {:?}", msg);
         let data = bincode::serialize(&msg)?;
         let len = (data.len() as u32).to_be_bytes();
         self.stream.write_all(&len).await?;
@@ -41,6 +42,7 @@ impl Transport for TcpTransport {
         let mut buf = vec![0u8; len];
         self.stream.read_exact(&mut buf).await?;
         let msg = bincode::deserialize(&buf)?;
+        log::debug!("tcp recv: {:?}", msg);
         Ok(msg)
     }
 }


### PR DESCRIPTION
## Summary
- add `log` crate behind the `std` feature
- log send/recv events for TCP and in-memory transports
- introduce env-configurable logging via `BATTLESHIP_LOG`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6898109d1bbc8329ae6553332f7aae73